### PR TITLE
allow meta.req as function

### DIFF
--- a/lib/winston-rollbar.js
+++ b/lib/winston-rollbar.js
@@ -63,7 +63,11 @@ Rollbar.prototype.log = function (level, msg, meta, callback) {
     if (this.metadataAsRequest) {
         if (req && req.socket) { req = meta; }
     } else if (meta && meta.req) {
-        req = meta.req;
+        if (typeof meta.req === 'function') {
+          req = meta.req();
+        } else {
+          req = meta.req;
+        }
     }
 
     if (/error/i.test(level) && (msg instanceof Error || meta instanceof Error)) {


### PR DESCRIPTION
this will allow sending `meta.req` as a getter function.
sending a request object in `meta` breaks loggers (like the default console one) when trying to serialize.
