### PR TITLE
change to use reportMessageWithPayloadData (incl. meta data)

### DIFF
--- a/lib/winston-rollbar.js
+++ b/lib/winston-rollbar.js
@@ -86,7 +86,11 @@ Rollbar.prototype.log = function (level, msg, meta, callback) {
             callback(null, true);
         });
     } else {
-        rollbar.reportMessage(msg, level, req, function (err) {
+        var options = {
+          level: level,
+          custom: meta
+        };
+        rollbar.reportMessageWithPayloadData(msg, options, req, function (err) {
             if (err) { return callback(err); }
 
             self.emit('logged');


### PR DESCRIPTION
Using a different method to report messages to Rollbar. The motivation is to have the ability to include Objects along with the message.

```
winston.warn("Checkout - Something went wrong. result:", result);
```

<img width="390" alt="screen shot 2015-08-29 at 7 23 12 pm" src="https://cloud.githubusercontent.com/assets/306321/9565422/729c3904-4e83-11e5-8169-1a4c358c827a.png">

"To report a string message, possibly along with additional context, use `reportMessage` or the full-powered `reportMessageWithPayloadData`."

Reference:
https://rollbar.com/docs/notifier/node_rollbar/#log-messages
